### PR TITLE
Set rec_name for payment order notification

### DIFF
--- a/account_payment_order_notification/models/account_payment_order_notification.py
+++ b/account_payment_order_notification/models/account_payment_order_notification.py
@@ -8,6 +8,7 @@ class AccountPaymentOrderNotification(models.Model):
     _name = "account.payment.order.notification"
     _description = "Payment Order Notification"
     _inherit = ["mail.thread"]
+    _rec_name = "display_name"
 
     order_id = fields.Many2one(
         comodel_name="account.payment.order",


### PR DESCRIPTION
I noticed this was missing in error logs when previewing mail templates. Was a little unsure if I could use a computed field, but tested and works.